### PR TITLE
feat(cc-catalog-svc): implement moving-pointer tag collapse for OCI sources

### DIFF
--- a/cc-catalog-svc/app/sources/oci.py
+++ b/cc-catalog-svc/app/sources/oci.py
@@ -86,19 +86,40 @@ class OCISource(ImageSource):
         # config-blob fetches reuse the same TCP connection / token.
         with httpx.Client(timeout=self.timeout, follow_redirects=True) as client:
             tags = self._list_tags(client, host, repo, auth_header=auth_header, auth_mode=auth_mode)
+            raw_set = set(tags)
+            default_ref = cc.get("default_ref", "main")
+
+            # Resolve moving pointers (`latest`, `main`, `pr-N`, …) up front.
+            # The build workflow stamps OCI labels on every image so we can
+            # derive the canonical tag from a single pointer manifest — no
+            # digest scan across thousands of historical `main-*` builds.
+            pointer_resolved: dict[str, DiscoveredImageRef] = {}
+            for pointer in self._pointer_tags_for_ref(default_ref, raw_set, default_ref):
+                winner = self._resolve_via_pointer(
+                    client,
+                    host,
+                    repo,
+                    pointer,
+                    default_ref,
+                    raw_set,
+                    auth_header,
+                    auth_mode,
+                )
+                if winner is not None:
+                    pointer_resolved[default_ref] = winner
+                    break
 
             discovered: list[DiscoveredImageRef] = []
             for tag in tags:
                 parsed = self._parse_tag(tag)
                 if parsed is None:
                     continue
+                if parsed.ref in pointer_resolved:
+                    continue
                 discovered.append(parsed)
 
-            # CI publishes moving-pointer aliases (`latest`, `main`, `pr-N`,
-            # …) alongside the immutable canonical tag. Trust those pointers
-            # instead of fetching manifests for every historical build of a
-            # ref — rw-cli-codecollection alone has thousands of `main-*`
-            # tags and only one row per ref in the catalog DB.
+            discovered.extend(pointer_resolved.values())
+
             discovered = self._collapse_via_pointer_tags(
                 client,
                 host,
@@ -108,10 +129,9 @@ class OCISource(ImageSource):
                 cc,
                 auth_header,
                 auth_mode,
+                pointer_resolved=pointer_resolved,
             )
 
-            # Fallback when no moving pointer exists (or digest lookup failed):
-            # fetch config.created for competing canonical tags.
             discovered = self._enrich_built_at_for_tiebreaks(
                 client, host, repo, discovered, auth_header, auth_mode
             )
@@ -360,6 +380,119 @@ class OCISource(ImageSource):
     # ------------------------------------------------------------------
     # moving-pointer collapse (latest / branch aliases)
     # ------------------------------------------------------------------
+    @staticmethod
+    def _pointer_tags_for_ref(
+        ref: str, raw_set: set[str], default_ref: str = "main"
+    ) -> list[str]:
+        """Moving aliases the build workflow publishes for ``ref``."""
+        pointers: list[str] = []
+        if ref == default_ref and "latest" in raw_set:
+            pointers.append("latest")
+        if ref in raw_set:
+            pointers.append(ref)
+        return pointers
+
+    def _resolve_via_pointer(
+        self,
+        client: httpx.Client,
+        host: str,
+        repo: str,
+        pointer_tag: str,
+        ref_name: str,
+        raw_set: set[str],
+        auth_header: Optional[str],
+        auth_mode: str,
+    ) -> Optional[DiscoveredImageRef]:
+        """Map a moving pointer to its canonical tag in O(1) registry calls.
+
+        Prefers OCI config labels (``io.runwhen.codecollection.commit``,
+        ``io.runwhen.runtime.commit``) baked in by the build workflow. Falls
+        back to a digest compare only when labels are missing (older images).
+        """
+        canonical_tag, built_at = self._canonical_tag_from_pointer_labels(
+            client,
+            host,
+            repo,
+            pointer_tag,
+            ref_name,
+            auth_header,
+            auth_mode,
+        )
+        if canonical_tag and canonical_tag in raw_set:
+            parsed = self._parse_tag(canonical_tag)
+            if parsed is not None and parsed.ref == ref_name:
+                if built_at is not None:
+                    parsed = dataclasses.replace(parsed, built_at=built_at)
+                return parsed
+
+        pointer_digest = self._manifest_digest(
+            client, host, repo, pointer_tag, auth_header, auth_mode
+        )
+        if not pointer_digest:
+            return None
+        for tag in raw_set:
+            parsed = self._parse_tag(tag)
+            if parsed is None or parsed.ref != ref_name:
+                continue
+            cand_digest = self._manifest_digest(
+                client, host, repo, tag, auth_header, auth_mode
+            )
+            if cand_digest == pointer_digest:
+                if built_at is not None:
+                    parsed = dataclasses.replace(parsed, built_at=built_at)
+                return parsed
+        return None
+
+    def _canonical_tag_from_pointer_labels(
+        self,
+        client: httpx.Client,
+        host: str,
+        repo: str,
+        pointer_tag: str,
+        ref_name: str,
+        auth_header: Optional[str],
+        auth_mode: str,
+    ) -> tuple[Optional[str], Optional[datetime]]:
+        """Read build labels from a pointer manifest and derive canonical tag."""
+        manifest_url = f"https://{host}/v2/{repo}/manifests/{pointer_tag}"
+        try:
+            resp = self._get_with_auth(
+                client,
+                host,
+                repo,
+                manifest_url,
+                params={},
+                auth_header=auth_header,
+                auth_mode=auth_mode,
+                accept=_MANIFEST_ACCEPT,
+            )
+            if resp.status_code != 200:
+                return None, None
+            manifest = resp.json()
+            blob = self._fetch_config_blob_from_manifest(
+                client, host, repo, manifest, auth_header, auth_mode
+            )
+            if blob is None:
+                return None, None
+            built_at = self._parse_created_timestamp(blob.get("created"))
+            labels = (blob.get("config") or {}).get("Labels") or {}
+            cc_sha = labels.get("io.runwhen.codecollection.commit") or labels.get(
+                "org.opencontainers.image.revision"
+            )
+            rt_sha = labels.get("io.runwhen.runtime.commit")
+            if not cc_sha or not rt_sha:
+                return None, built_at
+            canonical = f"{ref_name}-{cc_sha[:7]}-{rt_sha[:7]}"
+            return canonical, built_at
+        except Exception:
+            logger.debug(
+                "oci source: failed to read labels from pointer %s:%s",
+                repo,
+                pointer_tag,
+                exc_info=True,
+            )
+            return None, None
+
     def _collapse_via_pointer_tags(
         self,
         client: httpx.Client,
@@ -370,96 +503,46 @@ class OCISource(ImageSource):
         cc: dict,
         auth_header: Optional[str],
         auth_mode: str,
+        pointer_resolved: Optional[dict[str, DiscoveredImageRef]] = None,
     ) -> list[DiscoveredImageRef]:
-        """Keep one canonical tag per ref using registry pointer aliases.
-
-        The codecollection build workflow tags every push with both the
-        immutable ``<ref>-<cc_sha7>-<rt_sha7>`` tag AND a moving alias
-        (``latest`` on main, ``main`` for the branch, ``pr-N`` for PRs).
-        Those aliases point at the same manifest as the current build, so
-        we resolve the winner with digest equality instead of scanning
-        thousands of historical builds.
-        """
+        """Keep one canonical tag per ref using registry pointer aliases."""
         raw_set = set(raw_tags)
         default_ref = cc.get("default_ref", "main")
+        already_resolved = pointer_resolved or {}
         by_ref: dict[str, list[DiscoveredImageRef]] = {}
         for r in refs:
             by_ref.setdefault(r.ref, []).append(r)
 
         collapsed: list[DiscoveredImageRef] = []
         for ref, group in by_ref.items():
+            if ref in already_resolved:
+                collapsed.append(already_resolved[ref])
+                continue
             if len(group) == 1:
                 collapsed.append(group[0])
                 continue
 
-            pointers: list[str] = []
-            if ref == default_ref and "latest" in raw_set:
-                pointers.append("latest")
-            if ref in raw_set:
-                pointers.append(ref)
-
             winner: Optional[DiscoveredImageRef] = None
-            pointer_used: Optional[str] = None
-            for pointer in pointers:
-                winner = self._pick_canonical_via_pointer(
+            for pointer in self._pointer_tags_for_ref(ref, raw_set, default_ref):
+                winner = self._resolve_via_pointer(
                     client,
                     host,
                     repo,
                     pointer,
-                    group,
+                    ref,
+                    raw_set,
                     auth_header,
                     auth_mode,
                 )
                 if winner is not None:
-                    pointer_used = pointer
                     break
 
             if winner is None:
                 collapsed.extend(group)
-                continue
-
-            built_at = self._fetch_built_at_for_tag(
-                client,
-                host,
-                repo,
-                pointer_used or winner.image_tag,
-                auth_header,
-                auth_mode,
-            )
-            if built_at is not None:
-                winner = dataclasses.replace(winner, built_at=built_at)
-            collapsed.append(winner)
+            else:
+                collapsed.append(winner)
 
         return collapsed
-
-    def _pick_canonical_via_pointer(
-        self,
-        client: httpx.Client,
-        host: str,
-        repo: str,
-        pointer_tag: str,
-        candidates: list[DiscoveredImageRef],
-        auth_header: Optional[str],
-        auth_mode: str,
-    ) -> Optional[DiscoveredImageRef]:
-        """Return the candidate canonical tag that shares ``pointer_tag``'s digest."""
-        pointer_digest = self._manifest_digest(
-            client, host, repo, pointer_tag, auth_header, auth_mode
-        )
-        if not pointer_digest:
-            return None
-        for candidate in candidates:
-            cand_digest = self._manifest_digest(
-                client,
-                host,
-                repo,
-                candidate.image_tag,
-                auth_header,
-                auth_mode,
-            )
-            if cand_digest == pointer_digest:
-                return candidate
-        return None
 
     def _manifest_digest(
         self,
@@ -603,9 +686,12 @@ class OCISource(ImageSource):
                 return None
 
             manifest = resp.json()
-            return self._fetch_created_from_manifest(
+            blob = self._fetch_config_blob_from_manifest(
                 client, host, repo, manifest, auth_header, auth_mode
             )
+            if blob is None:
+                return None
+            return self._parse_created_timestamp(blob.get("created"))
         except Exception:
             logger.debug(
                 "oci source: failed to fetch built_at for %s:%s",
@@ -615,7 +701,7 @@ class OCISource(ImageSource):
             )
             return None
 
-    def _fetch_created_from_manifest(
+    def _fetch_config_blob_from_manifest(
         self,
         client: httpx.Client,
         host: str,
@@ -623,15 +709,8 @@ class OCISource(ImageSource):
         manifest: dict,
         auth_header: Optional[str],
         auth_mode: str,
-    ) -> Optional[datetime]:
-        """Resolve a manifest doc to its config-blob ``created`` timestamp.
-
-        Handles both single-platform manifests (``config.digest`` is on
-        the top-level) and image indices / manifest lists (we descend into
-        the first child manifest, which is the conventional approach since
-        all platforms of a multi-arch build share the same buildkit
-        timestamp anyway).
-        """
+    ) -> Optional[dict]:
+        """Return the image config blob JSON for a manifest document."""
         config_digest: Optional[str] = None
         child_manifests = manifest.get("manifests")
         if child_manifests:
@@ -670,16 +749,35 @@ class OCISource(ImageSource):
         )
         if blob_resp.status_code != 200:
             return None
-        created = blob_resp.json().get("created")
+        return blob_resp.json()
+
+    @staticmethod
+    def _parse_created_timestamp(created: Optional[str]) -> Optional[datetime]:
         if not created:
             return None
-        # OCI uses RFC 3339; normalize "Z" suffix for fromisoformat (<3.11).
         if created.endswith("Z"):
             created = created[:-1] + "+00:00"
         try:
             return datetime.fromisoformat(created)
         except ValueError:
             return None
+
+    def _fetch_created_from_manifest(
+        self,
+        client: httpx.Client,
+        host: str,
+        repo: str,
+        manifest: dict,
+        auth_header: Optional[str],
+        auth_mode: str,
+    ) -> Optional[datetime]:
+        """Resolve a manifest doc to its config-blob ``created`` timestamp."""
+        blob = self._fetch_config_blob_from_manifest(
+            client, host, repo, manifest, auth_header, auth_mode
+        )
+        if blob is None:
+            return None
+        return self._parse_created_timestamp(blob.get("created"))
 
     @staticmethod
     def _parse_next_link(link_header: str, host: str) -> Optional[str]:

--- a/cc-catalog-svc/app/sources/oci.py
+++ b/cc-catalog-svc/app/sources/oci.py
@@ -402,6 +402,7 @@ class OCISource(ImageSource):
         raw_set: set[str],
         auth_header: Optional[str],
         auth_mode: str,
+        candidate_tags: Optional[list[str]] = None,
     ) -> Optional[DiscoveredImageRef]:
         """Map a moving pointer to its canonical tag in O(1) registry calls.
 
@@ -418,19 +419,28 @@ class OCISource(ImageSource):
             auth_header,
             auth_mode,
         )
-        if canonical_tag and canonical_tag in raw_set:
+        if canonical_tag:
             parsed = self._parse_tag(canonical_tag)
             if parsed is not None and parsed.ref == ref_name:
                 if built_at is not None:
                     parsed = dataclasses.replace(parsed, built_at=built_at)
+                logger.info(
+                    "oci source: resolved %s via %s labels -> %s",
+                    ref_name,
+                    pointer_tag,
+                    canonical_tag,
+                )
                 return parsed
+
+        if not candidate_tags:
+            return None
 
         pointer_digest = self._manifest_digest(
             client, host, repo, pointer_tag, auth_header, auth_mode
         )
         if not pointer_digest:
             return None
-        for tag in raw_set:
+        for tag in candidate_tags:
             parsed = self._parse_tag(tag)
             if parsed is None or parsed.ref != ref_name:
                 continue
@@ -523,6 +533,7 @@ class OCISource(ImageSource):
                 continue
 
             winner: Optional[DiscoveredImageRef] = None
+            group_tags = [r.image_tag for r in group]
             for pointer in self._pointer_tags_for_ref(ref, raw_set, default_ref):
                 winner = self._resolve_via_pointer(
                     client,
@@ -533,6 +544,7 @@ class OCISource(ImageSource):
                     raw_set,
                     auth_header,
                     auth_mode,
+                    candidate_tags=group_tags,
                 )
                 if winner is not None:
                     break

--- a/cc-catalog-svc/app/sources/oci.py
+++ b/cc-catalog-svc/app/sources/oci.py
@@ -94,14 +94,24 @@ class OCISource(ImageSource):
                     continue
                 discovered.append(parsed)
 
-            # When multiple canonical tags share a ref (e.g. `main-<a>-<x>`
-            # AND `main-<b>-<y>`) we MUST pick the newer one. Lexicographic
-            # sort on `image_tag` is wrong: the cc_sha7 prefix is hex, so
-            # `main-1...` sorts before `main-d...` even when the `1...` push
-            # happened a week later. Fetch the real build timestamp from the
-            # registry so the existing (built_at, image_tag) sort produces a
-            # correct order. We only do this for tags that actually compete
-            # — most polls touch zero extra endpoints.
+            # CI publishes moving-pointer aliases (`latest`, `main`, `pr-N`,
+            # …) alongside the immutable canonical tag. Trust those pointers
+            # instead of fetching manifests for every historical build of a
+            # ref — rw-cli-codecollection alone has thousands of `main-*`
+            # tags and only one row per ref in the catalog DB.
+            discovered = self._collapse_via_pointer_tags(
+                client,
+                host,
+                repo,
+                tags,
+                discovered,
+                cc,
+                auth_header,
+                auth_mode,
+            )
+
+            # Fallback when no moving pointer exists (or digest lookup failed):
+            # fetch config.created for competing canonical tags.
             discovered = self._enrich_built_at_for_tiebreaks(
                 client, host, repo, discovered, auth_header, auth_mode
             )
@@ -346,6 +356,151 @@ class OCISource(ImageSource):
         if accept:
             retry_headers["Accept"] = accept
         return client.get(url, params=params, headers=retry_headers)
+
+    # ------------------------------------------------------------------
+    # moving-pointer collapse (latest / branch aliases)
+    # ------------------------------------------------------------------
+    def _collapse_via_pointer_tags(
+        self,
+        client: httpx.Client,
+        host: str,
+        repo: str,
+        raw_tags: list[str],
+        refs: list[DiscoveredImageRef],
+        cc: dict,
+        auth_header: Optional[str],
+        auth_mode: str,
+    ) -> list[DiscoveredImageRef]:
+        """Keep one canonical tag per ref using registry pointer aliases.
+
+        The codecollection build workflow tags every push with both the
+        immutable ``<ref>-<cc_sha7>-<rt_sha7>`` tag AND a moving alias
+        (``latest`` on main, ``main`` for the branch, ``pr-N`` for PRs).
+        Those aliases point at the same manifest as the current build, so
+        we resolve the winner with digest equality instead of scanning
+        thousands of historical builds.
+        """
+        raw_set = set(raw_tags)
+        default_ref = cc.get("default_ref", "main")
+        by_ref: dict[str, list[DiscoveredImageRef]] = {}
+        for r in refs:
+            by_ref.setdefault(r.ref, []).append(r)
+
+        collapsed: list[DiscoveredImageRef] = []
+        for ref, group in by_ref.items():
+            if len(group) == 1:
+                collapsed.append(group[0])
+                continue
+
+            pointers: list[str] = []
+            if ref == default_ref and "latest" in raw_set:
+                pointers.append("latest")
+            if ref in raw_set:
+                pointers.append(ref)
+
+            winner: Optional[DiscoveredImageRef] = None
+            pointer_used: Optional[str] = None
+            for pointer in pointers:
+                winner = self._pick_canonical_via_pointer(
+                    client,
+                    host,
+                    repo,
+                    pointer,
+                    group,
+                    auth_header,
+                    auth_mode,
+                )
+                if winner is not None:
+                    pointer_used = pointer
+                    break
+
+            if winner is None:
+                collapsed.extend(group)
+                continue
+
+            built_at = self._fetch_built_at_for_tag(
+                client,
+                host,
+                repo,
+                pointer_used or winner.image_tag,
+                auth_header,
+                auth_mode,
+            )
+            if built_at is not None:
+                winner = dataclasses.replace(winner, built_at=built_at)
+            collapsed.append(winner)
+
+        return collapsed
+
+    def _pick_canonical_via_pointer(
+        self,
+        client: httpx.Client,
+        host: str,
+        repo: str,
+        pointer_tag: str,
+        candidates: list[DiscoveredImageRef],
+        auth_header: Optional[str],
+        auth_mode: str,
+    ) -> Optional[DiscoveredImageRef]:
+        """Return the candidate canonical tag that shares ``pointer_tag``'s digest."""
+        pointer_digest = self._manifest_digest(
+            client, host, repo, pointer_tag, auth_header, auth_mode
+        )
+        if not pointer_digest:
+            return None
+        for candidate in candidates:
+            cand_digest = self._manifest_digest(
+                client,
+                host,
+                repo,
+                candidate.image_tag,
+                auth_header,
+                auth_mode,
+            )
+            if cand_digest == pointer_digest:
+                return candidate
+        return None
+
+    def _manifest_digest(
+        self,
+        client: httpx.Client,
+        host: str,
+        repo: str,
+        tag: str,
+        auth_header: Optional[str],
+        auth_mode: str,
+    ) -> Optional[str]:
+        """Best-effort manifest digest for an OCI tag (one GET, no blob fetch)."""
+        manifest_url = f"https://{host}/v2/{repo}/manifests/{tag}"
+        try:
+            resp = self._get_with_auth(
+                client,
+                host,
+                repo,
+                manifest_url,
+                params={},
+                auth_header=auth_header,
+                auth_mode=auth_mode,
+                accept=_MANIFEST_ACCEPT,
+            )
+            if resp.status_code != 200:
+                return None
+            digest = resp.headers.get("Docker-Content-Digest")
+            if digest:
+                return digest
+            manifest = resp.json()
+            child_manifests = manifest.get("manifests")
+            if child_manifests:
+                return (child_manifests[0] or {}).get("digest")
+            return None
+        except Exception:
+            logger.debug(
+                "oci source: failed to fetch digest for %s:%s",
+                repo,
+                tag,
+                exc_info=True,
+            )
+            return None
 
     # ------------------------------------------------------------------
     # tiebreak enrichment

--- a/cc-catalog-svc/tests/test_sources_oci.py
+++ b/cc-catalog-svc/tests/test_sources_oci.py
@@ -466,6 +466,57 @@ def test_discover_refs_enrichment_tolerates_per_tag_failure():
 
 
 @respx.mock
+def test_discover_refs_uses_latest_labels_when_canonical_tag_not_listed():
+    """GHCR tag lists can omit canonical tags; trust pointer labels anyway."""
+    src = OCISource()
+    repo_path = "runwhen-contrib/rw-cli-codecollection"
+    cc = {
+        "slug": "rw-cli-codecollection",
+        "image_registry": f"ghcr.io/{repo_path}",
+    }
+
+    respx.get(f"https://ghcr.io/v2/{repo_path}/tags/list").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "tags": [
+                    "latest",
+                    "main-aaaaaaa-bbbbbbb",
+                    "main-cccccccc-bbbbbbb",
+                ],
+            },
+        )
+    )
+
+    respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/latest").mock(
+        return_value=httpx.Response(
+            200,
+            json={"config": {"digest": "sha256:current-cfg"}},
+        )
+    )
+    respx.get(f"https://ghcr.io/v2/{repo_path}/blobs/sha256:current-cfg").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "created": "2026-05-21T17:00:00Z",
+                "config": {
+                    "Labels": {
+                        "io.runwhen.codecollection.commit": "1111111deadbeef",
+                        "io.runwhen.runtime.commit": "bbbbbbb0000000",
+                    }
+                },
+            },
+        )
+    )
+
+    refs = src.discover_refs(cc)
+    main_refs = [r for r in refs if r.ref == "main"]
+    assert len(main_refs) == 1
+    assert main_refs[0].image_tag == "main-1111111-bbbbbbb"
+    assert src.resolve_latest({"default_ref": "main"}, refs) == "main-1111111-bbbbbbb"
+
+
+@respx.mock
 def test_discover_refs_uses_latest_pointer_without_mass_enrichment():
     """When ``latest`` exists, read OCI labels — do not scan every ``main-*`` tag."""
     src = OCISource()

--- a/cc-catalog-svc/tests/test_sources_oci.py
+++ b/cc-catalog-svc/tests/test_sources_oci.py
@@ -467,12 +467,7 @@ def test_discover_refs_enrichment_tolerates_per_tag_failure():
 
 @respx.mock
 def test_discover_refs_uses_latest_pointer_without_mass_enrichment():
-    """When ``latest`` exists, trust it to pick the canonical tag.
-
-    The build workflow re-points ``:latest`` on every main push. We should
-    not fetch config blobs for every historical ``main-*`` build when the
-    registry already tells us which manifest is current.
-    """
+    """When ``latest`` exists, read OCI labels — do not scan every ``main-*`` tag."""
     src = OCISource()
     repo_path = "runwhen-contrib/rw-cli-codecollection"
     cc = {
@@ -497,27 +492,22 @@ def test_discover_refs_uses_latest_pointer_without_mass_enrichment():
     respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/latest").mock(
         return_value=httpx.Response(
             200,
-            headers={"Docker-Content-Digest": "sha256:current"},
             json={"config": {"digest": "sha256:current-cfg"}},
         )
     )
-    respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/main-1111111-bbbbbbb").mock(
-        return_value=httpx.Response(
-            200,
-            headers={"Docker-Content-Digest": "sha256:current"},
-            json={"config": {"digest": "sha256:current-cfg"}},
-        )
-    )
-    respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/main-aaaaaaa-bbbbbbb").mock(
-        return_value=httpx.Response(
-            200,
-            headers={"Docker-Content-Digest": "sha256:stale"},
-            json={"config": {"digest": "sha256:stale-cfg"}},
-        )
-    )
-    # built_at comes from the pointer manifest only (one blob fetch).
     respx.get(f"https://ghcr.io/v2/{repo_path}/blobs/sha256:current-cfg").mock(
-        return_value=httpx.Response(200, json={"created": "2026-05-21T17:00:00Z"})
+        return_value=httpx.Response(
+            200,
+            json={
+                "created": "2026-05-21T17:00:00Z",
+                "config": {
+                    "Labels": {
+                        "io.runwhen.codecollection.commit": "1111111deadbeef",
+                        "io.runwhen.runtime.commit": "bbbbbbb0000000",
+                    }
+                },
+            },
+        )
     )
 
     refs = src.discover_refs(cc)

--- a/cc-catalog-svc/tests/test_sources_oci.py
+++ b/cc-catalog-svc/tests/test_sources_oci.py
@@ -463,3 +463,67 @@ def test_discover_refs_enrichment_tolerates_per_tag_failure():
     # a known built_at outranks the bare-image_tag fallback (epoch_min).
     latest = src.resolve_latest({"default_ref": "main"}, refs)
     assert latest == "main-1111111-bbbbbbb"
+
+
+@respx.mock
+def test_discover_refs_uses_latest_pointer_without_mass_enrichment():
+    """When ``latest`` exists, trust it to pick the canonical tag.
+
+    The build workflow re-points ``:latest`` on every main push. We should
+    not fetch config blobs for every historical ``main-*`` build when the
+    registry already tells us which manifest is current.
+    """
+    src = OCISource()
+    repo_path = "runwhen-contrib/rw-cli-codecollection"
+    cc = {
+        "slug": "rw-cli-codecollection",
+        "image_registry": f"ghcr.io/{repo_path}",
+    }
+
+    respx.get(f"https://ghcr.io/v2/{repo_path}/tags/list").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "tags": [
+                    "latest",
+                    "main",
+                    "main-aaaaaaa-bbbbbbb",
+                    "main-1111111-bbbbbbb",
+                ],
+            },
+        )
+    )
+
+    respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/latest").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Docker-Content-Digest": "sha256:current"},
+            json={"config": {"digest": "sha256:current-cfg"}},
+        )
+    )
+    respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/main-1111111-bbbbbbb").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Docker-Content-Digest": "sha256:current"},
+            json={"config": {"digest": "sha256:current-cfg"}},
+        )
+    )
+    respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/main-aaaaaaa-bbbbbbb").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"Docker-Content-Digest": "sha256:stale"},
+            json={"config": {"digest": "sha256:stale-cfg"}},
+        )
+    )
+    # built_at comes from the pointer manifest only (one blob fetch).
+    respx.get(f"https://ghcr.io/v2/{repo_path}/blobs/sha256:current-cfg").mock(
+        return_value=httpx.Response(200, json={"created": "2026-05-21T17:00:00Z"})
+    )
+
+    refs = src.discover_refs(cc)
+    assert len(refs) == 1
+    assert refs[0].image_tag == "main-1111111-bbbbbbb"
+    assert refs[0].built_at is not None
+
+    latest = src.resolve_latest({"default_ref": "main"}, refs)
+    assert latest == "main-1111111-bbbbbbb"

--- a/cc-registry-v2/backend/app/sources/oci.py
+++ b/cc-registry-v2/backend/app/sources/oci.py
@@ -268,21 +268,31 @@ class OCISource(ImageSource):
         pointer_tag: str,
         ref_name: str,
         raw_set: set[str],
+        candidate_tags: Optional[list[str]] = None,
     ) -> Optional[DiscoveredImageRef]:
         canonical_tag, built_at = self._canonical_tag_from_pointer_labels(
             session, host, repo, pointer_tag, ref_name
         )
-        if canonical_tag and canonical_tag in raw_set:
+        if canonical_tag:
             parsed = self._parse_tag(canonical_tag)
             if parsed is not None and parsed.ref == ref_name:
                 if built_at is not None:
                     parsed = dataclasses.replace(parsed, built_at=built_at)
+                logger.info(
+                    "oci source: resolved %s via %s labels -> %s",
+                    ref_name,
+                    pointer_tag,
+                    canonical_tag,
+                )
                 return parsed
+
+        if not candidate_tags:
+            return None
 
         pointer_digest = self._manifest_digest(session, host, repo, pointer_tag)
         if not pointer_digest:
             return None
-        for tag in raw_set:
+        for tag in candidate_tags:
             parsed = self._parse_tag(tag)
             if parsed is None or parsed.ref != ref_name:
                 continue
@@ -358,9 +368,11 @@ class OCISource(ImageSource):
                 continue
 
             winner: Optional[DiscoveredImageRef] = None
+            group_tags = [r.image_tag for r in group]
             for pointer in self._pointer_tags_for_ref(ref, raw_set, default_ref):
                 winner = self._resolve_via_pointer(
-                    session, host, repo, pointer, ref, raw_set
+                    session, host, repo, pointer, ref, raw_set,
+                    candidate_tags=group_tags,
                 )
                 if winner is not None:
                     break

--- a/cc-registry-v2/backend/app/sources/oci.py
+++ b/cc-registry-v2/backend/app/sources/oci.py
@@ -104,14 +104,17 @@ class OCISource(ImageSource):
                     continue
                 discovered.append(ref)
 
-            # When multiple canonical tags share a ref (e.g. two builds
-            # of `main`) we MUST pick the newer one. Lex sort on
-            # image_tag is wrong: cc_sha7 is hex, so `main-1...` sorts
-            # before `main-d...` even when the `1...` push happened
-            # later. Fetch the real build timestamp from the registry
-            # so the existing (built_at, image_tag) sort picks the
-            # right tag. We only enrich tags that actually compete —
-            # single-tag-per-ref polls do zero extra HTTP work.
+            # CI publishes moving-pointer aliases (`latest`, `main`, `pr-N`,
+            # …) alongside the immutable canonical tag. Trust those pointers
+            # instead of fetching manifests for every historical build of a
+            # ref — rw-cli-codecollection alone has thousands of `main-*`
+            # tags and only one row per ref in the catalog DB.
+            discovered = self._collapse_via_pointer_tags(
+                session, host, repo, tags, discovered, cc
+            )
+
+            # Fallback when no moving pointer exists (or digest lookup failed):
+            # fetch config.created for competing canonical tags.
             discovered = self._enrich_built_at_for_tiebreaks(
                 session, host, repo, discovered
             )
@@ -234,6 +237,125 @@ class OCISource(ImageSource):
             timeout=self.timeout,
             headers=retry_headers,
         )
+
+    # ------------------------------------------------------------------
+    # moving-pointer collapse (latest / branch aliases)
+    # ------------------------------------------------------------------
+    def _collapse_via_pointer_tags(
+        self,
+        session: requests.Session,
+        host: str,
+        repo: str,
+        raw_tags: list[str],
+        refs: list[DiscoveredImageRef],
+        cc: dict,
+    ) -> list[DiscoveredImageRef]:
+        """Keep one canonical tag per ref using registry pointer aliases.
+
+        The codecollection build workflow tags every push with both the
+        immutable ``<ref>-<cc_sha7>-<rt_sha7>`` tag AND a moving alias
+        (``latest`` on main, ``main`` for the branch, ``pr-N`` for PRs).
+        Those aliases point at the same manifest as the current build, so
+        we resolve the winner with digest equality instead of scanning
+        thousands of historical builds.
+        """
+        raw_set = set(raw_tags)
+        default_ref = cc.get("default_ref", "main")
+        by_ref: dict[str, list[DiscoveredImageRef]] = {}
+        for r in refs:
+            by_ref.setdefault(r.ref, []).append(r)
+
+        collapsed: list[DiscoveredImageRef] = []
+        for ref, group in by_ref.items():
+            if len(group) == 1:
+                collapsed.append(group[0])
+                continue
+
+            pointers: list[str] = []
+            if ref == default_ref and "latest" in raw_set:
+                pointers.append("latest")
+            if ref in raw_set:
+                pointers.append(ref)
+
+            winner: Optional[DiscoveredImageRef] = None
+            pointer_used: Optional[str] = None
+            for pointer in pointers:
+                winner = self._pick_canonical_via_pointer(
+                    session, host, repo, pointer, group
+                )
+                if winner is not None:
+                    pointer_used = pointer
+                    break
+
+            if winner is None:
+                collapsed.extend(group)
+                continue
+
+            built_at = self._fetch_built_at_for_tag(
+                session, host, repo, pointer_used or winner.image_tag
+            )
+            if built_at is not None:
+                winner = dataclasses.replace(winner, built_at=built_at)
+            collapsed.append(winner)
+
+        return collapsed
+
+    def _pick_canonical_via_pointer(
+        self,
+        session: requests.Session,
+        host: str,
+        repo: str,
+        pointer_tag: str,
+        candidates: list[DiscoveredImageRef],
+    ) -> Optional[DiscoveredImageRef]:
+        """Return the candidate canonical tag that shares ``pointer_tag``'s digest."""
+        pointer_digest = self._manifest_digest(session, host, repo, pointer_tag)
+        if not pointer_digest:
+            return None
+        for candidate in candidates:
+            cand_digest = self._manifest_digest(
+                session, host, repo, candidate.image_tag
+            )
+            if cand_digest == pointer_digest:
+                return candidate
+        return None
+
+    def _manifest_digest(
+        self,
+        session: requests.Session,
+        host: str,
+        repo: str,
+        tag: str,
+    ) -> Optional[str]:
+        """Best-effort manifest digest for an OCI tag (one GET, no blob fetch)."""
+        manifest_url = f"https://{host}/v2/{repo}/manifests/{tag}"
+        try:
+            resp = self._get_with_token(
+                session,
+                host,
+                repo,
+                manifest_url,
+                params={},
+                accept=_MANIFEST_ACCEPT,
+            )
+            if resp.status_code != 200:
+                return None
+            digest = resp.headers.get("Docker-Content-Digest")
+            if digest:
+                return digest
+            manifest = resp.json()
+            child_manifests = manifest.get("manifests")
+            if child_manifests:
+                return (child_manifests[0] or {}).get("digest")
+            return None
+        except Exception:
+            logger.debug(
+                "oci source: failed to fetch digest for %s:%s",
+                repo,
+                tag,
+                exc_info=True,
+            )
+            return None
 
     # ------------------------------------------------------------------
     # tiebreak enrichment

--- a/cc-registry-v2/backend/app/sources/oci.py
+++ b/cc-registry-v2/backend/app/sources/oci.py
@@ -96,25 +96,33 @@ class OCISource(ImageSource):
         # config-blob fetches reuse the same TCP connection / token.
         with requests.Session() as session:
             tags = self._list_tags(session, host, repo)
+            raw_set = set(tags)
+            default_ref = cc.get("default_ref", "main")
+
+            pointer_resolved: dict[str, DiscoveredImageRef] = {}
+            for pointer in self._pointer_tags_for_ref(default_ref, raw_set, default_ref):
+                winner = self._resolve_via_pointer(
+                    session, host, repo, pointer, default_ref, raw_set
+                )
+                if winner is not None:
+                    pointer_resolved[default_ref] = winner
+                    break
 
             discovered: list[DiscoveredImageRef] = []
             for tag in tags:
                 ref = self._parse_tag(tag)
                 if ref is None:
                     continue
+                if ref.ref in pointer_resolved:
+                    continue
                 discovered.append(ref)
 
-            # CI publishes moving-pointer aliases (`latest`, `main`, `pr-N`,
-            # …) alongside the immutable canonical tag. Trust those pointers
-            # instead of fetching manifests for every historical build of a
-            # ref — rw-cli-codecollection alone has thousands of `main-*`
-            # tags and only one row per ref in the catalog DB.
+            discovered.extend(pointer_resolved.values())
+
             discovered = self._collapse_via_pointer_tags(
-                session, host, repo, tags, discovered, cc
+                session, host, repo, tags, discovered, cc, pointer_resolved
             )
 
-            # Fallback when no moving pointer exists (or digest lookup failed):
-            # fetch config.created for competing canonical tags.
             discovered = self._enrich_built_at_for_tiebreaks(
                 session, host, repo, discovered
             )
@@ -241,6 +249,88 @@ class OCISource(ImageSource):
     # ------------------------------------------------------------------
     # moving-pointer collapse (latest / branch aliases)
     # ------------------------------------------------------------------
+    @staticmethod
+    def _pointer_tags_for_ref(
+        ref: str, raw_set: set[str], default_ref: str = "main"
+    ) -> list[str]:
+        pointers: list[str] = []
+        if ref == default_ref and "latest" in raw_set:
+            pointers.append("latest")
+        if ref in raw_set:
+            pointers.append(ref)
+        return pointers
+
+    def _resolve_via_pointer(
+        self,
+        session: requests.Session,
+        host: str,
+        repo: str,
+        pointer_tag: str,
+        ref_name: str,
+        raw_set: set[str],
+    ) -> Optional[DiscoveredImageRef]:
+        canonical_tag, built_at = self._canonical_tag_from_pointer_labels(
+            session, host, repo, pointer_tag, ref_name
+        )
+        if canonical_tag and canonical_tag in raw_set:
+            parsed = self._parse_tag(canonical_tag)
+            if parsed is not None and parsed.ref == ref_name:
+                if built_at is not None:
+                    parsed = dataclasses.replace(parsed, built_at=built_at)
+                return parsed
+
+        pointer_digest = self._manifest_digest(session, host, repo, pointer_tag)
+        if not pointer_digest:
+            return None
+        for tag in raw_set:
+            parsed = self._parse_tag(tag)
+            if parsed is None or parsed.ref != ref_name:
+                continue
+            if self._manifest_digest(session, host, repo, tag) == pointer_digest:
+                if built_at is not None:
+                    parsed = dataclasses.replace(parsed, built_at=built_at)
+                return parsed
+        return None
+
+    def _canonical_tag_from_pointer_labels(
+        self,
+        session: requests.Session,
+        host: str,
+        repo: str,
+        pointer_tag: str,
+        ref_name: str,
+    ) -> tuple[Optional[str], Optional[datetime]]:
+        manifest_url = f"https://{host}/v2/{repo}/manifests/{pointer_tag}"
+        try:
+            resp = self._get_with_token(
+                session, host, repo, manifest_url, params={},
+                accept=_MANIFEST_ACCEPT,
+            )
+            if resp.status_code != 200:
+                return None, None
+            blob = self._fetch_config_blob_from_manifest(
+                session, host, repo, resp.json()
+            )
+            if blob is None:
+                return None, None
+            built_at = self._parse_created_timestamp(blob.get("created"))
+            labels = (blob.get("config") or {}).get("Labels") or {}
+            cc_sha = labels.get("io.runwhen.codecollection.commit") or labels.get(
+                "org.opencontainers.image.revision"
+            )
+            rt_sha = labels.get("io.runwhen.runtime.commit")
+            if not cc_sha or not rt_sha:
+                return None, built_at
+            return f"{ref_name}-{cc_sha[:7]}-{rt_sha[:7]}", built_at
+        except Exception:
+            logger.debug(
+                "oci source: failed to read labels from pointer %s:%s",
+                repo,
+                pointer_tag,
+                exc_info=True,
+            )
+            return None, None
+
     def _collapse_via_pointer_tags(
         self,
         session: requests.Session,
@@ -249,76 +339,38 @@ class OCISource(ImageSource):
         raw_tags: list[str],
         refs: list[DiscoveredImageRef],
         cc: dict,
+        pointer_resolved: Optional[dict[str, DiscoveredImageRef]] = None,
     ) -> list[DiscoveredImageRef]:
-        """Keep one canonical tag per ref using registry pointer aliases.
-
-        The codecollection build workflow tags every push with both the
-        immutable ``<ref>-<cc_sha7>-<rt_sha7>`` tag AND a moving alias
-        (``latest`` on main, ``main`` for the branch, ``pr-N`` for PRs).
-        Those aliases point at the same manifest as the current build, so
-        we resolve the winner with digest equality instead of scanning
-        thousands of historical builds.
-        """
         raw_set = set(raw_tags)
         default_ref = cc.get("default_ref", "main")
+        already_resolved = pointer_resolved or {}
         by_ref: dict[str, list[DiscoveredImageRef]] = {}
         for r in refs:
             by_ref.setdefault(r.ref, []).append(r)
 
         collapsed: list[DiscoveredImageRef] = []
         for ref, group in by_ref.items():
+            if ref in already_resolved:
+                collapsed.append(already_resolved[ref])
+                continue
             if len(group) == 1:
                 collapsed.append(group[0])
                 continue
 
-            pointers: list[str] = []
-            if ref == default_ref and "latest" in raw_set:
-                pointers.append("latest")
-            if ref in raw_set:
-                pointers.append(ref)
-
             winner: Optional[DiscoveredImageRef] = None
-            pointer_used: Optional[str] = None
-            for pointer in pointers:
-                winner = self._pick_canonical_via_pointer(
-                    session, host, repo, pointer, group
+            for pointer in self._pointer_tags_for_ref(ref, raw_set, default_ref):
+                winner = self._resolve_via_pointer(
+                    session, host, repo, pointer, ref, raw_set
                 )
                 if winner is not None:
-                    pointer_used = pointer
                     break
 
             if winner is None:
                 collapsed.extend(group)
-                continue
-
-            built_at = self._fetch_built_at_for_tag(
-                session, host, repo, pointer_used or winner.image_tag
-            )
-            if built_at is not None:
-                winner = dataclasses.replace(winner, built_at=built_at)
-            collapsed.append(winner)
+            else:
+                collapsed.append(winner)
 
         return collapsed
-
-    def _pick_canonical_via_pointer(
-        self,
-        session: requests.Session,
-        host: str,
-        repo: str,
-        pointer_tag: str,
-        candidates: list[DiscoveredImageRef],
-    ) -> Optional[DiscoveredImageRef]:
-        """Return the candidate canonical tag that shares ``pointer_tag``'s digest."""
-        pointer_digest = self._manifest_digest(session, host, repo, pointer_tag)
-        if not pointer_digest:
-            return None
-        for candidate in candidates:
-            cand_digest = self._manifest_digest(
-                session, host, repo, candidate.image_tag
-            )
-            if cand_digest == pointer_digest:
-                return candidate
-        return None
 
     def _manifest_digest(
         self,
@@ -451,9 +503,10 @@ class OCISource(ImageSource):
                 return None
 
             manifest = resp.json()
-            return self._fetch_created_from_manifest(
-                session, host, repo, manifest
-            )
+            blob = self._fetch_config_blob_from_manifest(session, host, repo, manifest)
+            if blob is None:
+                return None
+            return self._parse_created_timestamp(blob.get("created"))
         except Exception:
             logger.debug(
                 "oci source: failed to fetch built_at for %s:%s",
@@ -463,20 +516,13 @@ class OCISource(ImageSource):
             )
             return None
 
-    def _fetch_created_from_manifest(
+    def _fetch_config_blob_from_manifest(
         self,
         session: requests.Session,
         host: str,
         repo: str,
         manifest: dict,
-    ) -> Optional[datetime]:
-        """Resolve a manifest doc to its config-blob ``created`` timestamp.
-
-        Handles both single-platform manifests (``config.digest`` is on
-        the top-level) and image indices / manifest lists (descend into
-        the first child manifest — all platforms of a multi-arch build
-        share the same buildkit timestamp).
-        """
+    ) -> Optional[dict]:
         config_digest: Optional[str] = None
         child_manifests = manifest.get("manifests")
         if child_manifests:
@@ -498,21 +544,33 @@ class OCISource(ImageSource):
             return None
 
         blob_url = f"https://{host}/v2/{repo}/blobs/{config_digest}"
-        blob_resp = self._get_with_token(
-            session, host, repo, blob_url, params={}
-        )
+        blob_resp = self._get_with_token(session, host, repo, blob_url, params={})
         if blob_resp.status_code != 200:
             return None
-        created = blob_resp.json().get("created")
+        return blob_resp.json()
+
+    @staticmethod
+    def _parse_created_timestamp(created: Optional[str]) -> Optional[datetime]:
         if not created:
             return None
-        # OCI uses RFC 3339; normalize "Z" for fromisoformat (<3.11).
         if created.endswith("Z"):
             created = created[:-1] + "+00:00"
         try:
             return datetime.fromisoformat(created)
         except ValueError:
             return None
+
+    def _fetch_created_from_manifest(
+        self,
+        session: requests.Session,
+        host: str,
+        repo: str,
+        manifest: dict,
+    ) -> Optional[datetime]:
+        blob = self._fetch_config_blob_from_manifest(session, host, repo, manifest)
+        if blob is None:
+            return None
+        return self._parse_created_timestamp(blob.get("created"))
 
     @staticmethod
     def _parse_next_link(link_header: str, host: str) -> Optional[str]:


### PR DESCRIPTION
This update introduces a new method to collapse multiple canonical tags into a single reference using moving-pointer aliases like `latest` and branch-specific tags. The implementation optimizes the discovery process by reducing unnecessary manifest fetches for historical builds, relying instead on the current manifest pointed to by these aliases. Additionally, fallback logic is included to enrich competing canonical tags with their build timestamps when no moving pointer exists.

Tests have been added to ensure the correct behavior of the new functionality, verifying that the latest pointer is utilized effectively without mass enrichment of historical tags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which image tag the catalog reports as latest/stable for busy repos; wrong pointer/label logic could hide valid builds, though digest fallback and existing built_at tiebreaks limit exposure.
> 
> **Overview**
> **OCI image discovery** now resolves moving tags (`latest`, branch names like `main`) to a single canonical build tag per ref, instead of returning every historical `main-*` tag and relying on mass `built_at` enrichment to pick a winner.
> 
> For the default ref, discovery reads one pointer manifest (`latest` then the branch tag), derives the canonical tag from OCI config labels (`io.runwhen.codecollection.commit`, `io.runwhen.runtime.commit`), and skips duplicate canonical entries from the tag list. When several canonical tags still compete for the same ref, **`_collapse_via_pointer_tags`** picks one winner via the same pointer logic, with **digest comparison** as a fallback for images without labels. **`_enrich_built_at_for_tiebreaks`** remains for ambiguous cases where no pointer helps.
> 
> Manifest handling is refactored so label reads and timestamp tiebreaks share **`_fetch_config_blob_from_manifest`** and **`_parse_created_timestamp`**. The same behavior is ported to **`cc-catalog-svc`** (httpx) and **`cc-registry-v2`** (requests). New **respx** tests cover label-based resolution when the canonical tag is missing from the tag list and collapsing via `latest` without scanning every `main-*` tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd2cc7f1983dd44e53324350bb6b03466769535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->