### PR TITLE
feat(cc-catalog-svc, cc-registry-v2): enhance OCI source tag pagination and handling

### DIFF
--- a/cc-catalog-svc/app/sources/oci.py
+++ b/cc-catalog-svc/app/sources/oci.py
@@ -32,6 +32,7 @@ import os
 import re
 from datetime import datetime, timezone
 from typing import Optional
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 
@@ -60,6 +61,10 @@ _MANIFEST_ACCEPT = ",".join(
 
 class OCISource(ImageSource):
     name = "oci"
+
+    # Match crane / go-containerregistry. GHCR tag listing breaks when n=200:
+    # Link headers can carry n=0 and pagination loops over the same page.
+    TAGS_PAGE_SIZE = 1000
 
     def __init__(self, timeout: float = 10.0, max_pages: int = 50):
         # Defensive caps. A misbehaving registry shouldn't be able to
@@ -280,8 +285,9 @@ class OCISource(ImageSource):
     ) -> list[str]:
         """Walk /v2/<repo>/tags/list with Link-header pagination."""
         url = f"https://{host}/v2/{repo}/tags/list"
-        params: dict = {"n": 200}
+        params: dict = {"n": self.TAGS_PAGE_SIZE}
         all_tags: list[str] = []
+        seen: set[str] = set()
         for _ in range(self.max_pages):
             resp = self._get_with_auth(
                 client,
@@ -294,12 +300,17 @@ class OCISource(ImageSource):
             )
             resp.raise_for_status()
             payload = resp.json()
-            all_tags.extend(payload.get("tags") or [])
+            page_tags = payload.get("tags") or []
+            new_tags = [tag for tag in page_tags if tag not in seen]
+            if page_tags and not new_tags:
+                break
+            seen.update(new_tags)
+            all_tags.extend(new_tags)
             link = resp.headers.get("Link") or ""
             next_url = self._parse_next_link(link, host)
             if not next_url:
                 break
-            url, params = next_url, {}
+            url, params = self._next_tags_page_request(next_url)
         return all_tags
 
     def _get_with_auth(
@@ -801,6 +812,24 @@ class OCISource(ImageSource):
         if path.startswith("http"):
             return path
         return f"https://{host}{path}"
+
+    @classmethod
+    def _next_tags_page_request(cls, next_url: str) -> tuple[str, dict]:
+        """Turn a registry ``Link: ... rel=next`` URL into the next GET.
+
+        GHCR has been observed to emit ``n=0`` on subsequent pages when the
+        initial request used ``n=200``, which makes pagination loop forever.
+        We always send our own ``n=TAGS_PAGE_SIZE`` and carry forward only
+        the ``last`` cursor — matching crane / go-containerregistry.
+        """
+        parsed = urlparse(next_url)
+        query = parse_qs(parsed.query)
+        params: dict = {"n": cls.TAGS_PAGE_SIZE}
+        last_values = query.get("last") or []
+        if last_values:
+            params["last"] = last_values[0]
+        base_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+        return base_url, params
 
     @staticmethod
     def _parse_tag(tag: str) -> Optional[DiscoveredImageRef]:

--- a/cc-catalog-svc/tests/test_sources_oci.py
+++ b/cc-catalog-svc/tests/test_sources_oci.py
@@ -568,3 +568,95 @@ def test_discover_refs_uses_latest_pointer_without_mass_enrichment():
 
     latest = src.resolve_latest({"default_ref": "main"}, refs)
     assert latest == "main-1111111-bbbbbbb"
+
+
+@respx.mock
+def test_list_tags_requests_page_size_1000():
+    """Match crane / go-containerregistry: GHCR returns all tags in one page at n=1000."""
+    src = OCISource()
+    host = "ghcr.io"
+    repo = "runwhen-contrib/rw-cli-codecollection"
+    list_url = f"https://{host}/v2/{repo}/tags/list"
+    seen_params: list[dict] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        seen_params.append(dict(request.url.params))
+        return httpx.Response(
+            200,
+            json={"tags": ["main-c1a2b3d-e4f5a6b", "image-test-d86d320-7309089"]},
+        )
+
+    respx.get(list_url).mock(side_effect=capture)
+
+    with httpx.Client() as client:
+        tags = src._list_tags(client, host, repo)
+
+    assert seen_params[0]["n"] == "1000"
+    assert "image-test-d86d320-7309089" in tags
+
+
+@respx.mock
+def test_list_tags_rewrites_ghcr_zero_n_next_link():
+    """Regression: GHCR Link headers with n=0 must not loop or drop tail tags."""
+    src = OCISource()
+    host = "ghcr.io"
+    repo = "runwhen-contrib/rw-cli-codecollection"
+    list_url = f"https://{host}/v2/{repo}/tags/list"
+
+    first_page = [f"tag-{i:03d}-aaaaaaa-bbbbbbb" for i in range(200)]
+    tail_tags = ["image-test-d86d320-7309089", "image-test"]
+
+    def route_handler(request: httpx.Request) -> httpx.Response:
+        params = request.url.params
+        if "last" not in params:
+            return httpx.Response(
+                200,
+                json={"tags": first_page},
+                headers={
+                    "Link": (
+                        f'</v2/{repo}/tags/list?last=tag-199-aaaaaaa-bbbbbbb&n=0>; '
+                        'rel="next"'
+                    )
+                },
+            )
+        assert params.get("n") == "1000"
+        assert params.get("last") == "tag-199-aaaaaaa-bbbbbbb"
+        return httpx.Response(200, json={"tags": tail_tags})
+
+    respx.get(url=list_url).mock(side_effect=route_handler)
+    respx.get(url__regex=rf"{list_url}\?.*").mock(side_effect=route_handler)
+
+    with httpx.Client() as client:
+        tags = src._list_tags(client, host, repo)
+
+    assert "image-test-d86d320-7309089" in tags
+    assert "image-test" in tags
+    assert len(tags) == len(first_page) + len(tail_tags)
+
+
+@respx.mock
+def test_list_tags_stops_on_duplicate_page():
+    """If a registry keeps returning the same page, stop instead of spinning."""
+    src = OCISource(max_pages=10)
+    host = "ghcr.io"
+    repo = "runwhen-contrib/example"
+    list_url = f"https://{host}/v2/{repo}/tags/list"
+    page_tags = ["main-c1a2b3d-e4f5a6b", "main-aaaaaaa-bbbbbbb"]
+    call_count = {"n": 0}
+
+    def loop_handler(_request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(
+            200,
+            json={"tags": page_tags},
+            headers={"Link": f'</v2/{repo}/tags/list?last=main-aaaaaaa-bbbbbbb&n=0>; rel="next"'},
+        )
+
+    respx.get(url=list_url).mock(side_effect=loop_handler)
+    respx.get(url__regex=rf"{list_url}\?.*").mock(side_effect=loop_handler)
+
+    with httpx.Client() as client:
+        tags = src._list_tags(client, host, repo)
+
+    assert tags == page_tags
+    assert call_count["n"] == 2

--- a/cc-registry-v2/backend/app/sources/oci.py
+++ b/cc-registry-v2/backend/app/sources/oci.py
@@ -39,6 +39,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from typing import Optional
+from urllib.parse import parse_qs, urlparse
 
 import requests
 
@@ -71,6 +72,10 @@ _MANIFEST_ACCEPT = ",".join(
 
 class OCISource(ImageSource):
     name = "oci"
+
+    # Match crane / go-containerregistry. GHCR tag listing breaks when n=200:
+    # Link headers can carry n=0 and pagination loops over the same page.
+    TAGS_PAGE_SIZE = 1000
 
     def __init__(self, timeout: float = 10.0, max_pages: int = 50):
         # Defensive caps: a single CC shouldn't paginate forever, and
@@ -181,18 +186,24 @@ class OCISource(ImageSource):
     ) -> list[str]:
         """Walk the v2 tags endpoint with Link-header pagination."""
         url = f"https://{host}/v2/{repo}/tags/list"
-        params: dict = {"n": 200}
+        params: dict = {"n": self.TAGS_PAGE_SIZE}
         all_tags: list[str] = []
+        seen: set[str] = set()
         for _ in range(self.max_pages):
             resp = self._get_with_token(session, host, repo, url, params)
             resp.raise_for_status()
             payload = resp.json()
-            all_tags.extend(payload.get("tags") or [])
+            page_tags = payload.get("tags") or []
+            new_tags = [tag for tag in page_tags if tag not in seen]
+            if page_tags and not new_tags:
+                break
+            seen.update(new_tags)
+            all_tags.extend(new_tags)
             link = resp.headers.get("Link") or ""
             next_url = self._parse_next_link(link, host)
             if not next_url:
                 break
-            url, params = next_url, {}
+            url, params = self._next_tags_page_request(next_url)
         return all_tags
 
     def _get_with_token(
@@ -594,6 +605,24 @@ class OCISource(ImageSource):
         if path.startswith("http"):
             return path
         return f"https://{host}{path}"
+
+    @classmethod
+    def _next_tags_page_request(cls, next_url: str) -> tuple[str, dict]:
+        """Turn a registry ``Link: ... rel=next`` URL into the next GET.
+
+        GHCR has been observed to emit ``n=0`` on subsequent pages when the
+        initial request used ``n=200``, which makes pagination loop forever.
+        We always send our own ``n=TAGS_PAGE_SIZE`` and carry forward only
+        the ``last`` cursor — matching crane / go-containerregistry.
+        """
+        parsed = urlparse(next_url)
+        query = parse_qs(parsed.query)
+        params: dict = {"n": cls.TAGS_PAGE_SIZE}
+        last_values = query.get("last") or []
+        if last_values:
+            params["last"] = last_values[0]
+        base_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+        return base_url, params
 
     @staticmethod
     def _parse_tag(tag: str) -> Optional[DiscoveredImageRef]:


### PR DESCRIPTION
This update introduces a new TAGS_PAGE_SIZE constant to optimize tag listing requests for OCI sources, setting the default page size to 1000. The pagination logic has been improved to prevent infinite loops when encountering Link headers with n=0, ensuring that duplicate pages are detected and handled appropriately.

Additionally, a new method, _next_tags_page_request, has been added to manage the construction of subsequent requests based on the Link header, maintaining the correct pagination parameters.

Comprehensive tests have been added to validate the new pagination behavior and ensure that the system correctly handles edge cases, such as zero tags and duplicate pages, enhancing the robustness of the OCI source implementations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes read-only registry discovery used for catalog sync; behavior is safer but alters which tags are seen on large GHCR repos.
> 
> **Overview**
> Fixes **GHCR tag listing** in `OCISource` for both **cc-catalog-svc** and **cc-registry-v2** so discovery does not miss tags or spin on bad `Link` headers.
> 
> Tag list requests now use **`TAGS_PAGE_SIZE` 1000** (aligned with crane / go-containerregistry) instead of `n=200`. Follow-up pages are built via **`_next_tags_page_request`**, which keeps the `last` cursor but **always sends `n=1000`** and ignores GHCR’s broken `n=0` on `rel="next"` links that could cause infinite pagination. **`_list_tags`** also **dedupes** tags across pages and **stops** when a non-empty page adds no new tags.
> 
> **cc-catalog-svc** adds respx tests for page size, `n=0` link rewriting, and duplicate-page bailout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6418056a0e441e865cebe926d4ba1d29a540ba9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->