### PR TITLE
fix(cc-catalog-svc, cc-registry-v2): update pointer tag resolution logic and enhance tests

### DIFF
--- a/.github/workflows/cc-catalog-svc.yaml
+++ b/.github/workflows/cc-catalog-svc.yaml
@@ -1,24 +1,13 @@
-name: Build cc-catalog-svc
+name: Build cc-catalog-svc (PR / dev)
 
-# Standalone build pipeline for the cc-catalog-svc microservice.
+# PR validation and ad-hoc dev builds only.
 #
-# Kept separate from build-images.yaml / release.yaml on purpose:
-#   * cc-catalog-svc is its own deployable; pinning it to the cc-registry-v2
-#     release cadence would be wrong.
-#
-# Registries:
-#   * GAR — internal dev/test (every PR + main push)
-#   * GHCR — public release surface (main push only, date-tagged)
+# Date-tagged releases (YYYY-MM-DD.N) are cut by release.yaml together with
+# cc-registry-v2 and mcp-server. Every image in that release — including
+# ghcr.io/runwhen-contrib/cc-catalog-svc — shares the same tag.
 
 on:
   pull_request:
-    paths:
-      - 'cc-catalog-svc/**'
-      - '.github/workflows/cc-catalog-svc.yaml'
-
-  push:
-    branches:
-      - main
     paths:
       - 'cc-catalog-svc/**'
       - '.github/workflows/cc-catalog-svc.yaml'
@@ -37,19 +26,10 @@ on:
         description: 'Custom image tag (default: <branch>-<sha8>)'
         required: false
         type: string
-      cut_release:
-        description: 'Cut date-based release + push to GHCR (main behaviour)'
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
 
 env:
   GCP_PROJECT_ID: runwhen-nonprod-shared
   GCR_REGISTRY: us-docker.pkg.dev/runwhen-nonprod-shared/public-images
-  GHCR_IMAGE: ghcr.io/runwhen-contrib/cc-catalog-svc
   IMAGE_NAME: cc-catalog-svc
 
 permissions:
@@ -59,63 +39,15 @@ permissions:
   actions: read
 
 jobs:
-  create-release:
-    name: Create Release Tag
-    runs-on: ubuntu-latest
-    if: >-
-      (github.event_name == 'push' && github.ref_name == 'main') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.cut_release == 'true')
-    permissions:
-      contents: write
-    outputs:
-      release_tag: ${{ steps.create_release.outputs.release_tag }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create date-based tag and GitHub Release
-        id: create_release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git config --global user.name "${GITHUB_ACTOR}"
-
-          # Same YYYY-MM-DD.N scheme as release.yaml; image name disambiguates.
-          # Use `git tag --list` (not grep): with set -e, grep exits 1 when there
-          # are no tags for today yet and the step fails before tagging.
-          BASE_TAG=$(date "+%Y-%m-%d")
-          last=$(git tag --list "${BASE_TAG}.*" | awk -F '.' '{print $NF}' | sort -n | tail -1)
-          next=$([ -z "$last" ] && echo 1 || echo $((last + 1)))
-          NEW_TAG="${BASE_TAG}.${next}"
-
-          git tag "${NEW_TAG}"
-          git push origin "${NEW_TAG}"
-
-          gh release create "${NEW_TAG}" \
-            --title "cc-catalog-svc ${NEW_TAG}" \
-            --generate-notes
-
-          echo "release_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Created release ${NEW_TAG}"
-
   build:
     name: Build & Push
     runs-on: ubuntu-latest
-    needs: [create-release]
-    if: >-
-      always() &&
-      (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
     permissions:
       contents: read
       id-token: write
-      packages: write
       pull-requests: write
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
-      release_tag: ${{ needs.create-release.outputs.release_tag }}
       should_push: ${{ steps.push.outputs.should_push }}
     steps:
       - uses: actions/checkout@v4
@@ -140,35 +72,6 @@ jobs:
             echo "should_push=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Compute image tags
-        id: tags
-        run: |
-          set -euo pipefail
-          TAGS=""
-          append() { TAGS="${TAGS}${TAGS:+$'\n'}${1}"; }
-
-          # GAR (internal CI)
-          append "${GCR_REGISTRY}/${IMAGE_NAME}:${{ steps.tag.outputs.tag }}"
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_name }}" = "main" ]; then
-            append "${GCR_REGISTRY}/${IMAGE_NAME}:main"
-            append "${GCR_REGISTRY}/${IMAGE_NAME}:latest"
-          fi
-
-          # GHCR (public release) — only when we cut a release tag on this run
-          RELEASE_TAG="${{ needs.create-release.outputs.release_tag }}"
-          if [ -n "${RELEASE_TAG}" ]; then
-            append "${GHCR_IMAGE}:${RELEASE_TAG}"
-            append "${GHCR_IMAGE}:latest"
-          fi
-
-          {
-            echo "tags<<EOF"
-            echo "${TAGS}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-          echo "Tags:"
-          echo "${TAGS}"
-
       - name: Authenticate to Google Cloud
         if: steps.push.outputs.should_push == 'true'
         uses: google-github-actions/auth@v2
@@ -180,16 +83,6 @@ jobs:
         if: steps.push.outputs.should_push == 'true'
         run: gcloud --quiet auth configure-docker us-docker.pkg.dev
 
-      - name: Log in to GHCR
-        if: >-
-          steps.push.outputs.should_push == 'true' &&
-          needs.create-release.outputs.release_tag != ''
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -200,7 +93,8 @@ jobs:
           file: cc-catalog-svc/Dockerfile
           platforms: linux/amd64
           push: ${{ steps.push.outputs.should_push == 'true' }}
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: |
+            ${{ env.GCR_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
           cache-from: type=gha,scope=cc-catalog-svc
           cache-to: type=gha,mode=max,scope=cc-catalog-svc
           build-args: |
@@ -209,20 +103,6 @@ jobs:
             BAKE_GIT_MIRRORS=true
           secrets: |
             github_token=${{ secrets.GITHUB_TOKEN }}
-
-      - name: Release summary
-        if: needs.create-release.outputs.release_tag != ''
-        run: |
-          TAG="${{ needs.create-release.outputs.release_tag }}"
-          {
-            echo "## cc-catalog-svc release: \`${TAG}\`"
-            echo ""
-            echo "| Registry | Image |"
-            echo "|----------|-------|"
-            echo "| GHCR | \`${GHCR_IMAGE}:${TAG}\` |"
-            echo "| GHCR (floating) | \`${GHCR_IMAGE}:latest\` |"
-            echo "| GAR (CI) | \`${GCR_REGISTRY}/${IMAGE_NAME}:${{ steps.tag.outputs.tag }}\` |"
-          } >> "$GITHUB_STEP_SUMMARY"
 
   comment-on-pr:
     name: PR Comment
@@ -246,7 +126,8 @@ jobs:
               `| Image | Tag |\n` +
               `|-------|-----|\n` +
               `| \`${image}\` | \`${tag}\` |\n\n` +
-              `\`\`\`\n${registry}/${image}:${tag}\n\`\`\``;
+              `\`\`\`\n${registry}/${image}:${tag}\n\`\`\`\n\n` +
+              `> Date-tagged GHCR releases are published by \`release.yaml\` on merge to \`main\`.`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'cc-registry-v2/**'
+      - 'cc-catalog-svc/**'
       - 'mcp-server/**'
       - '.github/workflows/release.yaml'
 
@@ -14,6 +15,7 @@ on:
 env:
   GCP_PROJECT_ID: runwhen-nonprod-shared
   GCR_REGISTRY: us-docker.pkg.dev/runwhen-nonprod-shared/public-images
+  GHCR_CC_CATALOG_IMAGE: ghcr.io/runwhen-contrib/cc-catalog-svc
 
 permissions:
   contents: write
@@ -226,13 +228,68 @@ jobs:
             GITHUB_REF=${{ github.ref }}
 
   # ---------------------------------------------------------------------------
+  # cc-catalog-svc image (GHCR — runwhen-env deploy surface)
+  # ---------------------------------------------------------------------------
+
+  build-cc-catalog-svc:
+    name: Build cc-catalog-svc
+    runs-on: ubuntu-latest
+    needs: [create-release]
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.RUNWHEN_NONPROD_SHARED_WI_PROVIDER }}
+          service_account: ${{ secrets.RUNWHEN_NONPROD_SHARED_WI_SA }}
+
+      - name: Configure Docker for GCR
+        run: gcloud --quiet auth configure-docker us-docker.pkg.dev
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push cc-catalog-svc
+        uses: docker/build-push-action@v5
+        with:
+          context: cc-catalog-svc
+          file: cc-catalog-svc/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.GHCR_CC_CATALOG_IMAGE }}:${{ needs.create-release.outputs.release_tag }}
+            ${{ env.GHCR_CC_CATALOG_IMAGE }}:latest
+            ${{ env.GCR_REGISTRY }}/cc-catalog-svc:${{ needs.create-release.outputs.release_tag }}
+            ${{ env.GCR_REGISTRY }}/cc-catalog-svc:latest
+          cache-from: type=gha,scope=cc-catalog-svc
+          cache-to: type=gha,mode=max,scope=cc-catalog-svc
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_REF=${{ github.ref }}
+            BAKE_GIT_MIRRORS=true
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
+
+  # ---------------------------------------------------------------------------
   # Deploy all images to prod with the same tag
   # ---------------------------------------------------------------------------
 
   deploy-to-prod:
     name: Deploy Release to Prod
     runs-on: ubuntu-latest
-    needs: [create-release, build-backend, build-frontend, build-worker, build-mcp-server]
+    needs: [create-release, build-backend, build-frontend, build-worker, build-mcp-server, build-cc-catalog-svc]
     steps:
       # NOTE: `infra-flux-nonprod-shared` is intentionally the *single* Flux
       # hub for both the test and the prod registry clusters — there is no
@@ -272,7 +329,7 @@ jobs:
   summary:
     name: Release Summary
     runs-on: ubuntu-latest
-    needs: [create-release, build-backend, build-frontend, build-worker, build-mcp-server, deploy-to-prod]
+    needs: [create-release, build-backend, build-frontend, build-worker, build-mcp-server, build-cc-catalog-svc, deploy-to-prod]
     if: always()
     steps:
       - name: Build summary
@@ -287,13 +344,15 @@ jobs:
           echo "| Frontend | ${{ needs.build-frontend.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Worker | ${{ needs.build-worker.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| MCP Server | ${{ needs.build-mcp-server.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| cc-catalog-svc | ${{ needs.build-cc-catalog-svc.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Prod Deploy | ${{ needs.deploy-to-prod.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           REGISTRY="us-docker.pkg.dev/runwhen-nonprod-shared/public-images"
           ALL_OK=true
           for result in "${{ needs.build-backend.result }}" "${{ needs.build-frontend.result }}" \
-                        "${{ needs.build-worker.result }}" "${{ needs.build-mcp-server.result }}"; do
+                        "${{ needs.build-worker.result }}" "${{ needs.build-mcp-server.result }}" \
+                        "${{ needs.build-cc-catalog-svc.result }}"; do
             [ "$result" != "success" ] && ALL_OK=false
           done
 
@@ -304,6 +363,8 @@ jobs:
             echo "${REGISTRY}/cc-registry-v2-frontend:${TAG}" >> $GITHUB_STEP_SUMMARY
             echo "${REGISTRY}/cc-registry-v2-worker:${TAG}" >> $GITHUB_STEP_SUMMARY
             echo "${REGISTRY}/runwhen-mcp-server:${TAG}" >> $GITHUB_STEP_SUMMARY
+            echo "${{ env.GHCR_CC_CATALOG_IMAGE }}:${TAG}" >> $GITHUB_STEP_SUMMARY
+            echo "${REGISTRY}/cc-catalog-svc:${TAG}" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ Some builds failed" >> $GITHUB_STEP_SUMMARY

--- a/cc-catalog-svc/app/sources/oci.py
+++ b/cc-catalog-svc/app/sources/oci.py
@@ -94,7 +94,7 @@ class OCISource(ImageSource):
             raw_set = set(tags)
             default_ref = cc.get("default_ref", "main")
 
-            # Resolve moving pointers (`latest`, `main`, `pr-N`, …) up front.
+            # Resolve moving pointers (`main`, `latest`, `pr-N`, …) up front.
             # The build workflow stamps OCI labels on every image so we can
             # derive the canonical tag from a single pointer manifest — no
             # digest scan across thousands of historical `main-*` builds.
@@ -395,12 +395,17 @@ class OCISource(ImageSource):
     def _pointer_tags_for_ref(
         ref: str, raw_set: set[str], default_ref: str = "main"
     ) -> list[str]:
-        """Moving aliases the build workflow publishes for ``ref``."""
+        """Moving aliases the build workflow publishes for ``ref``.
+
+        Branch aliases (``:main``) are tried before ``:latest``. The build
+        workflow updates ``:main`` on every main build (push or dispatch),
+        while ``:latest`` is only repointed on push — so ``:latest`` can lag.
+        """
         pointers: list[str] = []
-        if ref == default_ref and "latest" in raw_set:
-            pointers.append("latest")
         if ref in raw_set:
             pointers.append(ref)
+        if ref == default_ref and "latest" in raw_set:
+            pointers.append("latest")
         return pointers
 
     def _resolve_via_pointer(

--- a/cc-catalog-svc/tests/test_sources_oci.py
+++ b/cc-catalog-svc/tests/test_sources_oci.py
@@ -38,6 +38,15 @@ def test_parse_tag_rejects_non_schema_tags():
     assert src._parse_tag("1.2.3") is None
 
 
+def test_pointer_tags_for_ref_prefers_branch_over_latest():
+    raw = {"latest", "main", "main-aaaaaaa-bbbbbbb"}
+    assert OCISource._pointer_tags_for_ref("main", raw) == ["main", "latest"]
+    # Fall back to :latest only when the branch alias tag is absent.
+    assert OCISource._pointer_tags_for_ref("main", {"latest", "main-aaaaaaa-bbbbbbb"}) == [
+        "latest"
+    ]
+
+
 def test_resolve_latest_picks_default_ref():
     src = OCISource()
     refs = [
@@ -517,8 +526,81 @@ def test_discover_refs_uses_latest_labels_when_canonical_tag_not_listed():
 
 
 @respx.mock
+def test_discover_refs_prefers_main_pointer_over_stale_latest():
+    """workflow_dispatch rebuilds update :main but not :latest."""
+    src = OCISource()
+    repo_path = "runwhen-contrib/rw-cli-codecollection"
+    cc = {
+        "slug": "rw-cli-codecollection",
+        "image_registry": f"ghcr.io/{repo_path}",
+    }
+
+    respx.get(f"https://ghcr.io/v2/{repo_path}/tags/list").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "tags": [
+                    "latest",
+                    "main",
+                    "main-b3fd306-d286953",
+                    "main-b3fd306-4d7e73c",
+                ],
+            },
+        )
+    )
+
+    respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/main").mock(
+        return_value=httpx.Response(
+            200,
+            json={"config": {"digest": "sha256:main-cfg"}},
+        )
+    )
+    respx.get(f"https://ghcr.io/v2/{repo_path}/blobs/sha256:main-cfg").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "created": "2026-07-23T03:09:00Z",
+                "config": {
+                    "Labels": {
+                        "io.runwhen.codecollection.commit": "b3fd306deadbeef",
+                        "io.runwhen.runtime.commit": "4d7e73c0000000",
+                    }
+                },
+            },
+        )
+    )
+
+    respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/latest").mock(
+        return_value=httpx.Response(
+            200,
+            json={"config": {"digest": "sha256:latest-cfg"}},
+        )
+    )
+    respx.get(f"https://ghcr.io/v2/{repo_path}/blobs/sha256:latest-cfg").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "created": "2026-07-20T03:14:00Z",
+                "config": {
+                    "Labels": {
+                        "io.runwhen.codecollection.commit": "b3fd306deadbeef",
+                        "io.runwhen.runtime.commit": "d2869530000000",
+                    }
+                },
+            },
+        )
+    )
+
+    refs = src.discover_refs(cc)
+    main_refs = [r for r in refs if r.ref == "main"]
+    assert len(main_refs) == 1
+    assert main_refs[0].image_tag == "main-b3fd306-4d7e73c"
+    assert src.resolve_latest({"default_ref": "main"}, refs) == "main-b3fd306-4d7e73c"
+
+
+@respx.mock
 def test_discover_refs_uses_latest_pointer_without_mass_enrichment():
-    """When ``latest`` exists, read OCI labels — do not scan every ``main-*`` tag."""
+    """When branch and latest pointers exist, read OCI labels — no mass scan."""
     src = OCISource()
     repo_path = "runwhen-contrib/rw-cli-codecollection"
     cc = {
@@ -540,6 +622,12 @@ def test_discover_refs_uses_latest_pointer_without_mass_enrichment():
         )
     )
 
+    respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/main").mock(
+        return_value=httpx.Response(
+            200,
+            json={"config": {"digest": "sha256:current-cfg"}},
+        )
+    )
     respx.get(f"https://ghcr.io/v2/{repo_path}/manifests/latest").mock(
         return_value=httpx.Response(
             200,

--- a/cc-registry-v2/backend/app/sources/oci.py
+++ b/cc-registry-v2/backend/app/sources/oci.py
@@ -264,11 +264,12 @@ class OCISource(ImageSource):
     def _pointer_tags_for_ref(
         ref: str, raw_set: set[str], default_ref: str = "main"
     ) -> list[str]:
+        """Branch alias before ``:latest`` — dispatch rebuilds move ``:main`` only."""
         pointers: list[str] = []
-        if ref == default_ref and "latest" in raw_set:
-            pointers.append("latest")
         if ref in raw_set:
             pointers.append(ref)
+        if ref == default_ref and "latest" in raw_set:
+            pointers.append("latest")
         return pointers
 
     def _resolve_via_pointer(


### PR DESCRIPTION
This commit refines the logic for resolving moving pointers in the OCISource class. The order of preference for branch aliases has been adjusted to prioritize `:main` over `:latest`, ensuring that the latest build is correctly identified. Additionally, the docstring for the `_pointer_tags_for_ref` method has been expanded to clarify the behavior of branch aliases and their interaction with the `:latest` tag.

New tests have been added to validate the updated pointer resolution logic, confirming that the system correctly prefers branch tags over the latest tag when both are present. This enhancement improves the accuracy of tag resolution in OCI sources, ensuring more reliable image discovery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release and image-publish paths changed for cc-catalog-svc (timing and registries), and catalog “latest” resolution behavior changes when :latest is stale—both affect what image tags deploys and discovery report.
> 
> **Overview**
> **cc-catalog-svc** date-tagged **GHCR** releases move from the dedicated workflow into **`release.yaml`**, so they share the same **`YYYY-MM-DD.N`** tag as cc-registry-v2 and mcp-server. The **`cc-catalog-svc`** workflow is narrowed to **PR validation** and **workflow_dispatch** dev builds that push a single **GAR** image; it no longer runs on **`main`**, cuts releases, or publishes to GHCR. PR comments now point readers at **`release.yaml`** for public releases.
> 
> In **`cc-catalog-svc`** and **`cc-registry-v2`**, **`_pointer_tags_for_ref`** now resolves the branch alias (**`:main`**) before **`:latest`**, because dispatch rebuilds refresh **`:main`** while **`:latest`** can lag. Tests cover that preference when both pointers exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda313f144654c6da8fb05f03539132cdf37b84b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->