### PR TITLE
fix: dependency updates and CVE remediation (cc-catalog-svc, python deps, react-router)

### DIFF
--- a/cc-catalog-svc/Dockerfile
+++ b/cc-catalog-svc/Dockerfile
@@ -21,8 +21,8 @@
 # Read-only-rootfs friendly: the only writable path the service needs is
 # /data (SQLite DB + crane's auth cache). Mount a volume there in k8s.
 
-ARG PYTHON_VERSION=3.12-slim
-ARG CRANE_VERSION=v0.20.2
+ARG PYTHON_VERSION=3.12.13-slim
+ARG CRANE_VERSION=v0.21.8
 ARG BAKE_GIT_MIRRORS=true
 ARG BAKE_CONFIG=config-examples/config.bake.yaml
 

--- a/cc-registry-v2/backend/requirements.txt
+++ b/cc-registry-v2/backend/requirements.txt
@@ -1,17 +1,17 @@
 # FastAPI and core dependencies
 fastapi==0.104.1
-uvicorn[standard]==0.24.0
-pydantic==2.5.0
-pydantic-settings==2.1.0
+uvicorn[standard]==0.52.1
+pydantic==2.13.4
+pydantic-settings==2.14.2
 
 # Database
-sqlalchemy==2.0.23
-alembic==1.13.1
-psycopg2-binary==2.9.9
+sqlalchemy==2.0.51
+alembic==1.19.0
+psycopg2-binary==2.9.12
 pgvector>=0.2.4
 
 # HTTP client
-httpx==0.25.2
+httpx==0.28.1
 
 # Authentication
 python-jose[cryptography]==3.3.0
@@ -19,8 +19,8 @@ passlib[bcrypt]==1.7.4
 python-multipart==0.0.6
 
 # Background tasks
-celery==5.3.4
-redis==5.0.1
+celery==5.6.3
+redis==5.3.1
 flower==2.0.1
 
 # GitHub integration
@@ -30,7 +30,7 @@ PyGithub==1.59.1
 GitPython==3.1.40
 
 # YAML and templating
-PyYAML==6.0.1
+PyYAML==6.0.3
 Jinja2==3.1.2
 
 # Robot Framework
@@ -46,12 +46,12 @@ lxml>=4.9.0
 
 # Testing
 pytest==7.4.3
-pytest-asyncio==0.21.1
+pytest-asyncio==0.26.0
 pytest-cov==4.1.0
 
 # Development
 black==23.11.0
-isort==5.12.0
+isort==5.13.2
 flake8==6.1.0
 
 # Environment

--- a/cc-registry-v2/backend/requirements.txt
+++ b/cc-registry-v2/backend/requirements.txt
@@ -45,7 +45,7 @@ beautifulsoup4>=4.12.0
 lxml>=4.9.0
 
 # Testing
-pytest==7.4.3
+pytest==8.3.5
 pytest-asyncio==0.26.0
 pytest-cov==4.1.0
 

--- a/cc-registry-v2/frontend/package-lock.json
+++ b/cc-registry-v2/frontend/package-lock.json
@@ -3563,9 +3563,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -15997,12 +15997,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
-      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -16012,13 +16012,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/cc-registry-v2/worker/requirements.txt
+++ b/cc-registry-v2/worker/requirements.txt
@@ -3,28 +3,28 @@
 
 # FastAPI and core dependencies
 fastapi==0.104.1
-uvicorn[standard]==0.24.0
-pydantic==2.5.0
-pydantic-settings==2.1.0
+uvicorn[standard]==0.52.1
+pydantic==2.13.4
+pydantic-settings==2.14.2
 
 # Database
-sqlalchemy==2.0.23
-alembic==1.13.1
-psycopg2-binary==2.9.9
+sqlalchemy==2.0.51
+alembic==1.19.0
+psycopg2-binary==2.9.12
 pgvector>=0.2.4
 
 # HTTP client
-httpx==0.25.2
+httpx==0.28.1
 
 # Background tasks
-celery==5.3.4
-redis==5.0.1
+celery==5.6.3
+redis==5.3.1
 
 # Git operations
 GitPython==3.1.40
 
 # YAML and templating
-PyYAML==6.0.1
+PyYAML==6.0.3
 Jinja2==3.1.2
 
 # Robot Framework

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-robotframework==6.0.2
+robotframework==6.1.1
 gitpython>=3.1.41
 jinja2>=3.1
 jsonschema>=4.21


### PR DESCRIPTION
## Summary

Single consolidated PR combining all dependency updates to fix CVEs across the repo.

### Changes

**cc-catalog-svc/Dockerfile (CVE fixes):**
- `CRANE_VERSION: v0.20.2 → v0.21.8` — The Go-built `crane` binary from `google/go-containerregistry` updated to latest release (v0.21.8), shipping Go 1.26.5 with critical runtime/dependency CVE patches
- `PYTHON_VERSION: 3.12-slim → 3.12.13-slim` — Pinned to specific patch version for deterministic builds

**Python dependencies (cc-registry-v2 backend + worker):**
- uvicorn 0.24.0 → 0.52.1
- pydantic 2.5.0 → 2.13.4
- pydantic-settings 2.1.0 → 2.14.2
- sqlalchemy 2.0.23 → 2.0.51
- alembic 1.13.1 → 1.19.0
- httpx 0.25.2 → 0.28.1
- celery 5.3.4 → 5.6.3
- redis 5.0.1 → 5.3.1
- PyYAML 6.0.1 → 6.0.3
- psycopg2-binary 2.9.9 → 2.9.12
- pytest-asyncio 0.21.1 → 0.26.0
- isort 5.12.0 → 5.13.2

**Root requirements.txt:**
- robotframework 6.0.2 → 6.1.1

**Frontend:**
- react-router-dom 6.30.1 → 6.30.4
- react-router 6.30.1 → 6.30.4
- @remix-run/router 1.23.0 → 1.23.3

### Why consolidated

Previously split across PRs #146 (Python deps), #147 (react-router), and #163 (cc-catalog-svc CVE fixes). Combined into one PR for single-release simplicity.